### PR TITLE
Fix segmentation fault for null XDG_CONFIG_HOME

### DIFF
--- a/main.c
+++ b/main.c
@@ -54,7 +54,7 @@ char* getshell(void) {
   if (home != NULL) {
     char* home_result;
     asprintf(&home_result, "%s/.config/%s", home, relpath);
-    if (strcmp(home_result, xdg_result) && usable(home_result)) {
+    if (usable(home_result)) {
       return home_result;
     };
   }


### PR DESCRIPTION
If the `XDG_CONFIG_HOME` is null, `xdg_result` will also be NULL. But `xdg_result` is used every time in check for usability of the HOME envvar. This leads to segfault on my machine when I start noshell with both my user and root.

One solution would be to just make another check if it is not null, but if I understand the code correctly this was just to discard the `HOME` early before the call to `usable` was made, if it was same as `xdg_result`. This seems unnecessary to me and seems prone to bugs like this one.

Of course I can update the PR to just check for the null if you wish.